### PR TITLE
Add GitHub CMS blog support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Blog via GitHub CMS
+
+This project uses [Decap CMS](https://decapcms.org/) (formerly Netlify CMS) to manage blog posts stored in the `src/posts` folder. The CMS is configured with a GitHub backend so new posts are committed directly to this repository.
+
+To access the editor, open `/admin` when the site is running. Log in with your GitHub account and you will be able to create or edit Markdown/MDX posts.

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -1,0 +1,21 @@
+backend:
+  name: github
+  repo: your-github-username/web-dev-frontend-
+  branch: main
+
+media_folder: "public/assets/uploads"
+public_folder: "/assets/uploads"
+
+collections:
+  - name: "posts"
+    label: "Posts"
+    folder: "src/posts"
+    create: true
+    slug: "{{slug}}"
+    extension: "mdx"
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - { label: "Publish Date", name: "date", widget: "datetime" }
+      - { label: "Author", name: "author", widget: "string" }
+      - { label: "Tags", name: "tags", widget: "list" }
+      - { label: "Body", name: "body", widget: "markdown" }

--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Content Manager</title>
+    <script src="https://unpkg.com/decap-cms@^2.12.0/dist/decap-cms.js"></script>
+  </head>
+  <body></body>
+</html>

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
-// Load all Markdown files
-const posts = import.meta.glob('../posts/*.md', { eager: true });
+// Load all Markdown files (MDX)
+const posts = import.meta.glob('../posts/*.mdx', { eager: true });
 
 export default function BlogPage() {
   const blogEntries = Object.entries(posts).map(([path, post]) => {
-    const slug = path.split('/').pop().replace('.md', '');
+    const slug = path.split('/').pop().replace('.mdx', '');
     return {
       ...post.metadata,
       slug,


### PR DESCRIPTION
## Summary
- load blog posts from `.mdx`
- integrate Decap CMS in `/public/admin`
- configure GitHub backend for blog posts
- document how to edit posts via GitHub CMS

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683f92df4260832c98d50398d8872deb