### PR TITLE
Fix missing MDX plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "devDependencies": {
     "eslint": "^8.0.0",
     "vite": "^4.0.0",
-    "jest": "^29.0.0"
+    "jest": "^29.0.0",
+    "@mdx-js/rollup": "^2.3.0",
+    "remark-frontmatter": "^3.0.0",
+    "remark-mdx-frontmatter": "^1.0.0"
   }
 }

--- a/src/utils/sum.js
+++ b/src/utils/sum.js
@@ -1,0 +1,4 @@
+function sum(a, b) {
+  return a + b;
+}
+module.exports = sum;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,19 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import mdx from '@mdx-js/rollup';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
 
 export default defineConfig({
-  plugins: [react(), mdx()],
+  plugins: [
+    react(),
+    mdx({
+      remarkPlugins: [
+        remarkFrontmatter,
+        [remarkMdxFrontmatter, { name: 'metadata' }]
+      ]
+    })
+  ],
   server: {
     historyApiFallback: true
   }


### PR DESCRIPTION
## Summary
- include `@mdx-js/rollup` and related remark packages
- configure Vite to load MDX with frontmatter support

## Testing
- `npm run lint` *(fails: several lint errors)*
- `npm run test` *(fails: jest not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684303b5d214832c82ea195b3ccf7dab