### PR TITLE
Add registration email function

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,12 @@ If patching fails because files already exist, review the `.rej` files and apply
    cause errors like `Cannot find module '@mdx-js/rollup'` when running
    `npm run dev`.
 >>>>>>> theirs
+
+### Environment variables
+
+To enable the registration email feature, set the following variables in your Netlify project or a local `.env` file:
+
+- `PERSONAL_EMAIL` – destination address for form submissions. If unset, messages are delivered to `wise11jeff@gmail.com`.
+- `SENDGRID_API_KEY` – API key used by the serverless function to send mail
+
+These are required for the `netlify/functions/sendRegistration.js` function.

--- a/netlify/functions/sendRegistration.js
+++ b/netlify/functions/sendRegistration.js
@@ -1,0 +1,59 @@
+exports.handler = async function(event) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  let data;
+  try {
+    data = JSON.parse(event.body || '{}');
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  }
+
+  const { name, email, project } = data;
+  if (!name || !email || !project) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Missing fields' }) };
+  }
+
+  const destEmail = process.env.PERSONAL_EMAIL || 'wise11jeff@gmail.com';
+
+  const message = {
+    personalizations: [
+      {
+        to: [{ email: destEmail }],
+      },
+    ],
+    from: { email: destEmail },
+    subject: 'New Registration',
+    content: [
+      {
+        type: 'text/plain',
+        value: `Name: ${name}\nEmail: ${email}\nProject: ${project}`,
+      },
+    ],
+  };
+
+  try {
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${process.env.SENDGRID_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(message),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text);
+    }
+
+    return { statusCode: 200, body: JSON.stringify({ success: true }) };
+  } catch (err) {
+    console.error('Email send failed:', err);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to send email' }),
+    };
+  }
+};

--- a/src/components/ChatWidget.jsx
+++ b/src/components/ChatWidget.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+
+export default function ChatWidget() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [input, setInput] = useState('');
+  const [status, setStatus] = useState(null); // 'success' | 'error'
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/.netlify/functions/sendRegistration', {
+        method: 'POST',
+        body: JSON.stringify({ name, email, project: input }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setStatus('success');
+    } catch (err) {
+      console.error(err);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="p-4 border rounded max-w-sm">
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+          required
+        />
+        <textarea
+          placeholder="Tell us about your project"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="w-full border px-3 py-2 rounded"
+          rows={3}
+          required
+        />
+        <button
+          type="submit"
+          className="bg-primary text-white px-4 py-2 rounded w-full"
+        >
+          Send
+        </button>
+      </form>
+      {status === 'success' && (
+        <p className="text-green-600 mt-2">Thanks! We'll be in touch.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-600 mt-2">Something went wrong. Please try again.</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create Netlify function to forward registration info to email via SendGrid
- add ChatWidget component that posts to serverless function and displays success/error messages
- document required `PERSONAL_EMAIL` and `SENDGRID_API_KEY` env vars
- default registration emails to `wise11jeff@gmail.com`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689564e6ebc4832c836449f2da1df30a