### PR TITLE
Redesign homepage with AI-focused hero and sections

### DIFF
--- a/src/components/AiToolsTeaser.jsx
+++ b/src/components/AiToolsTeaser.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function AiToolsTeaser() {
+  return (
+    <section className="py-16 px-4 bg-gray-50 text-center">
+      <div className="max-w-4xl mx-auto">
+        <h2 className="text-2xl md:text-3xl font-heading font-bold text-primary mb-4">AI Tools for Builders</h2>
+        <p className="text-text mb-6">Create headlines, copy and landing pages in seconds.</p>
+        <Link
+          to="/ai"
+          className="inline-block text-accent font-semibold hover:underline"
+          aria-label="Browse AI tools"
+        >
+          Explore AI Tools →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ClosingCTA.jsx
+++ b/src/components/ClosingCTA.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function ClosingCTA() {
+  return (
+    <section className="py-20 px-4 bg-primary text-center text-white">
+      <div className="max-w-4xl mx-auto">
+        <h2 className="text-3xl md:text-4xl font-heading font-bold mb-4">Ready to build with AI?</h2>
+        <p className="text-lg mb-8">Launch faster with tools designed for growth.</p>
+        <a
+          href="https://webmasterypro.com/ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block bg-accent text-primary px-8 py-4 rounded-full font-semibold hover:bg-yellow-400 transition-transform transform hover:scale-105"
+          aria-label="Get started with AI tools"
+        >
+          Get Started
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,66 +1,27 @@
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { motion as Motion, AnimatePresence } from 'framer-motion';
-
-const rotatingWords = ['Elegance', 'Speed', 'Precision', 'Impact'];
+import React from 'react';
 
 export default function Hero() {
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setIndex((prev) => (prev + 1) % rotatingWords.length);
-    }, 2500);
-    return () => clearInterval(interval);
-  }, []);
-
   return (
-    <section className="relative overflow-hidden bg-white text-center py-16 md:py-20 px-4">
-      <div className="absolute top-[-100px] left-[-100px] w-[300px] h-[300px] bg-accent opacity-10 rounded-full blur-3xl z-0" />
+    <section className="relative overflow-hidden bg-white text-center py-24 px-4">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-b from-white to-gray-50" />
 
-      <div className="relative z-10 max-w-4xl mx-auto">
-        <div className="w-16 h-1 bg-accent mx-auto mb-6 rounded-full" />
-
-        <h1 className="text-4xl md:text-5xl font-heading font-extrabold text-primary tracking-tight leading-tight mb-4">
-          Build Your Vision with{' '}
-          <AnimatePresence mode="wait">
-            <Motion.span
-              key={rotatingWords[index]}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
-              transition={{ duration: 0.5 }}
-              className="inline-block text-accent"
-            >
-              {rotatingWords[index]}
-            </Motion.span>
-          </AnimatePresence>
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-4xl md:text-5xl font-heading font-extrabold text-primary mb-6">
+          Launch faster with AI-driven websites
         </h1>
-
         <p className="text-text font-body text-base md:text-lg leading-relaxed max-w-2xl mx-auto mb-8">
-          We craft beautiful, high-performance websites and applications that elevate your brand and grow your business.
+          Automate copy, design and optimization so you can focus on growth.
         </p>
 
-        <Link
-          to="/pricing"
-          className="inline-block bg-accent text-white px-6 py-3 rounded-full text-lg font-medium hover:bg-yellow-500 transition-transform transform hover:scale-105 shadow-md"
+        <a
+          href="https://webmasterypro.com/ai"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block bg-accent text-white px-8 py-4 rounded-full text-lg font-medium hover:bg-yellow-500 transition-transform transform hover:scale-105 shadow-md"
+          aria-label="Explore AI tools"
         >
-          🚀 Get Started
-        </Link>
-      </div>
-
-      <div className="absolute bottom-0 left-0 w-full overflow-hidden leading-[0]">
-        <svg
-          className="relative block w-full h-[60px]"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 1440 320"
-        >
-          <path
-            fill="#ffffff"
-            fillOpacity="1"
-            d="M0,160L40,149.3C80,139,160,117,240,128C320,139,400,181,480,186.7C560,192,640,160,720,138.7C800,117,880,107,960,117.3C1040,128,1120,160,1200,165.3C1280,171,1360,149,1400,138.7L1440,128L1440,320L1400,320C1360,320,1280,320,1200,320C1120,320,1040,320,960,320C880,320,800,320,720,320C640,320,560,320,480,320C400,320,320,320,240,320C160,320,80,320,40,320L0,320Z"
-          ></path>
-        </svg>
+          Try the AI Toolkit
+        </a>
       </div>
     </section>
   );

--- a/src/components/HomeServices.jsx
+++ b/src/components/HomeServices.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCode, faRobot, faChartLine, faBolt } from '@fortawesome/free-solid-svg-icons';
+
+const services = [
+  {
+    title: 'Custom Websites',
+    description: 'Responsive designs built to convert.',
+    icon: faCode,
+  },
+  {
+    title: 'AI Integration',
+    description: 'Automate content and workflows.',
+    icon: faRobot,
+  },
+  {
+    title: 'SEO Growth',
+    description: 'Rank higher with data-driven strategy.',
+    icon: faChartLine,
+  },
+  {
+    title: 'Automation',
+    description: 'Save time with smart systems.',
+    icon: faBolt,
+  },
+];
+
+export default function HomeServices() {
+  return (
+    <section id="services" className="py-20 px-4 bg-white">
+      <div className="max-w-6xl mx-auto text-center">
+        <h2 className="text-3xl md:text-4xl font-heading font-bold text-primary mb-3">Services</h2>
+        <p className="text-text mb-12 max-w-2xl mx-auto">Everything you need to launch and grow with AI.</p>
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+          {services.map((service) => (
+            <div key={service.title} className="p-6 bg-gray-50 rounded-lg shadow hover:shadow-lg transition">
+              <FontAwesomeIcon icon={service.icon} className="text-accent text-3xl mb-4" aria-hidden="true" />
+              <h3 className="text-xl font-semibold mb-2">{service.title}</h3>
+              <p className="text-sm text-text">{service.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/SocialProof.jsx
+++ b/src/components/SocialProof.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export default function SocialProof() {
+  return (
+    <section className="py-16 px-4 bg-gray-50">
+      <div className="max-w-6xl mx-auto text-center">
+        <h2 className="text-2xl md:text-3xl font-heading font-bold text-primary mb-8">Trusted by creators</h2>
+        <div className="flex flex-wrap justify-center items-center gap-8 mb-12">
+          <div className="h-12 w-32 bg-gray-200 rounded" aria-hidden="true"></div>
+          <div className="h-12 w-32 bg-gray-200 rounded" aria-hidden="true"></div>
+          <div className="h-12 w-32 bg-gray-200 rounded" aria-hidden="true"></div>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          <blockquote className="bg-white p-6 rounded-lg shadow text-sm text-text">
+            <p>"This AI toolkit saved us days of work."</p>
+            <cite className="mt-4 block font-semibold text-primary">Happy Client</cite>
+          </blockquote>
+          <blockquote className="bg-white p-6 rounded-lg shadow text-sm text-text">
+            <p>"Our launch was twice as fast."</p>
+            <cite className="mt-4 block font-semibold text-primary">Startup Founder</cite>
+          </blockquote>
+          <blockquote className="bg-white p-6 rounded-lg shadow text-sm text-text">
+            <p>"The automation features are game changers."</p>
+            <cite className="mt-4 block font-semibold text-primary">Agency Owner</cite>
+          </blockquote>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,27 +1,18 @@
 import React from 'react';
 import Hero from '../components/Hero.jsx';
-import BusinessNameGenerator from '../components/BusinessNameGenerator.jsx';
-import Services from '../components/Services.jsx';
-import Projects from '../components/Projects.jsx';
-import Contact from '../components/Contact.jsx';
+import AiToolsTeaser from '../components/AiToolsTeaser.jsx';
+import HomeServices from '../components/HomeServices.jsx';
+import SocialProof from '../components/SocialProof.jsx';
+import ClosingCTA from '../components/ClosingCTA.jsx';
 
 export default function HomePage() {
   return (
     <>
-      {/* 1. First Impression - Strong CTA */}
       <Hero />
-
-      {/* 2. Immediate Value (Tool or Lead Magnet) */}
-      <BusinessNameGenerator />
-
-      {/* 3. What You Offer - Services Overview */}
-      <Services />
-
-      {/* 4. Build Trust - Show Past Work */}
-      <Projects />
-
-      {/* 5. Convert - Make it Easy to Reach You */}
-      <Contact />
+      <AiToolsTeaser />
+      <HomeServices />
+      <SocialProof />
+      <ClosingCTA />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- replace hero with AI-focused messaging and external CTA
- add teaser for AI tools and service highlights
- introduce social proof grid and closing CTA

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7496b580832ca6475344acafd77b